### PR TITLE
README: indent copyright and license notices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,21 +74,21 @@ License
 The Python script ``codespell.py`` is available with the following terms:
 (*tl;dr*: `GPL v2`_)
 
-> Copyright (C) 2010-2011  Lucas De Marchi <lucas.de.marchi@gmail.com>
+   Copyright (C) 2010-2011  Lucas De Marchi <lucas.de.marchi@gmail.com>
 
-> Copyright (C) 2011  ProFUSION embedded systems
+   Copyright (C) 2011  ProFUSION embedded systems
 
-> This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; version 2 of the License.
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
 
-> This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
 
-> You should have received a copy of the GNU General Public License
-along with this program; if not, see
-<http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>.
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see
+   <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>.
 
 .. _GPL v2: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
Another leftover from Markdown→reST conversion.