### PR TITLE
Change the line numbering in display to 1-based

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -443,7 +443,7 @@ def parse_file(filename, colors, summary):
                     continue
 
                 cfilename = "%s%s%s" % (colors.FILE, filename, colors.DISABLE)
-                cline = "%s%d%s" % (colors.FILE, i+1, colors.DISABLE)
+                cline = "%s%d%s" % (colors.FILE, i + 1, colors.DISABLE)
                 cwrongword = "%s%s%s" % (colors.WWORD, word, colors.DISABLE)
                 crightword = "%s%s%s" % (colors.FWORD, fixword, colors.DISABLE)
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -443,7 +443,7 @@ def parse_file(filename, colors, summary):
                     continue
 
                 cfilename = "%s%s%s" % (colors.FILE, filename, colors.DISABLE)
-                cline = "%s%d%s" % (colors.FILE, i, colors.DISABLE)
+                cline = "%s%d%s" % (colors.FILE, i+1, colors.DISABLE)
                 cwrongword = "%s%s%s" % (colors.WWORD, word, colors.DISABLE)
                 crightword = "%s%s%s" % (colors.FWORD, fixword, colors.DISABLE)
 


### PR DESCRIPTION
Codespell prints one less line numbers than the real one. This was caused by assigning loop counter 'i' to 'cline' directory, so I fixed it by assigning "'i' + 1" to cline.
