### PR TITLE
Fix off-by-one error

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -420,7 +420,7 @@ def parse_file(filename, colors, summary):
                 fixword = fix_case(word, misspellings[lword].data)
 
                 if options.interactive and lword not in asked_for:
-                    fix, fixword = ask_for_word_fix(lines[i - 1], word,
+                    fix, fixword = ask_for_word_fix(lines[i], word,
                                                     misspellings[lword],
                                                     options.interactive)
                     asked_for.add(lword)


### PR DESCRIPTION
I don't know whether or not this is in the specifications.
When I used codespell with interactive mode, it printed one previous line of the line that includes misspelled words and then printed choices. I checked parse_file() and found that it's calling ask_for_word_fix() with argument "line[i - 1]", so I modified it to "line[i]".