### PR TITLE
Improve skipping directories

### DIFF
--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -579,11 +579,12 @@ def main(*args):
 
         if os.path.isdir(filename):
             for root, dirs, files in os.walk(filename):
+                if glob_match.match(root):  # skip (absolute) directories
+                    del dirs[:]
+                    continue
                 for file_ in files:
                     fname = os.path.join(root, file_)
                     if not os.path.isfile(fname) or not os.path.getsize(fname):
-                        continue
-                    if glob_match.match(root):  # skips also match directories
                         continue
                     if glob_match.match(file_):
                         continue

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -590,6 +590,9 @@ def main(*args):
                         continue
                     bad_count += parse_file(fname, colors, summary)
 
+                # skip (relative) directories
+                dirs[:] = [dir_ for dir_ in dirs if not glob_match.match(dir_)]
+
         else:
             bad_count += parse_file(filename, colors, summary)
 

--- a/codespell_lib/_codespell.py
+++ b/codespell_lib/_codespell.py
@@ -583,10 +583,10 @@ def main(*args):
                     del dirs[:]
                     continue
                 for file_ in files:
+                    if glob_match.match(file_):
+                        continue
                     fname = os.path.join(root, file_)
                     if not os.path.isfile(fname) or not os.path.getsize(fname):
-                        continue
-                    if glob_match.match(file_):
                         continue
                     bad_count += parse_file(fname, colors, summary)
 

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -1991,7 +1991,7 @@ formallize->formalize
 formallized->formalized
 formaly->formally, formerly,
 formated->formatted
-formating->formating
+formating->formatting
 formelly->formerly
 formidible->formidable
 formost->foremost
@@ -4696,7 +4696,7 @@ uncertainity->uncertainty
 unchaged->unchanged
 unchallengable->unchallengeable
 unchangable->unchangeable
-uncoment->uncoment
+uncoment->uncomment
 uncompetive->uncompetitive
 unconcious->unconscious
 unconciousness->unconsciousness

--- a/codespell_lib/tests/test_basic.py
+++ b/codespell_lib/tests/test_basic.py
@@ -245,6 +245,7 @@ def test_ignore():
         assert_equal(cs.main(d), 2)
         assert_equal(cs.main('--skip=bad*', d), 0)
         assert_equal(cs.main('--skip=*ignoredir*', d), 1)
+        assert_equal(cs.main('--skip=ignoredir', d), 1)
 
 
 class TemporaryDirectory(object):


### PR DESCRIPTION
Stop traversing into sub directories, if a directory is matched by --skip.
Also allow --skip to match the directory name only (and not only the absolute path).
Fix two cases were the correction was the same as the wrong spelling.