### PR TITLE
amin->main, disable because of var names

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -297,6 +297,7 @@ ambigous->ambiguous
 amendmant->amendment
 Amercia->America
 amerliorate->ameliorate
+amin->main, disabled because of var names
 amke->make
 amking->making
 ammend->amend


### PR DESCRIPTION
found this as a typo but we'd probably get some false positives with this. If adding 'disable because of var names' will that help?