### PR TITLE
refined an existing spelling correction

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2593,7 +2593,7 @@ instal->install
 instalation->installation
 instaled->installed
 instaling->installing
-installe->installer
+installe->installer, installed, install,
 instanciate->instantiate
 instanciated->instantiated
 instanciation->instantiation


### PR DESCRIPTION
from 
`installe->installer`
to
`installe->installer, installed, install,`