### PR TITLE
Add get's->gets

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -2193,6 +2193,7 @@ geometricians->geometers
 geometrie->geometry
 gerat->great
 german->German
+get's->gets
 gettetx->gettext
 Ghandi->Gandhi
 glight->flight


### PR DESCRIPTION
I figured that if the person put an apostrophe perhaps they could also mean `gets us` even though that is totally gramitcally incorrect.