### PR TITLE
Remove 'anymore'

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -354,7 +354,6 @@ anual->annual
 anulled->annulled
 anwsered->answered
 anyhwere->anywhere
-anymore->any more
 anyother->any other
 anytying->anything
 aparent->apparent


### PR DESCRIPTION
Per https://dictionary.cambridge.org/us/grammar/british-grammar/any-more-or-anymore 
both are valid.