### PR TITLE
wasn->wasn't, was,

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5183,7 +5183,7 @@ warnig->warning
 warrent->warrant
 warrriors->warriors
 was't->wasn't
-wasn->was
+wasn->wasn't, was,
 wasnt'->wasn't
 wasnt->wasn't
 wass->was


### PR DESCRIPTION
Safe to assume that if they typed an `n` that they may have meant `wasn't` so I added it.