### PR TITLE
Add zoon->zoom, zoon,

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5291,3 +5291,4 @@ yrea->year
 ytou->you
 yuo->you
 zeebra->zebra
+zoon->zoom, zoon,


### PR DESCRIPTION
TIL that `zoon` is an actual word. Nevertheless, I thought this entry was merited since on a qwerty keyboard 'n' is next to 'm'.