### PR TITLE
Add undependend->independent, nondependent,

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5106,6 +5106,7 @@ uncontitutional->unconstitutional
 unconvential->unconventional
 undecideable->undecidable
 undefuned->undefined
+undependend->independent, nondependent,
 understoon->understood
 undesireable->undesirable
 undetecable->undetectable


### PR DESCRIPTION
Context:
```
[foo@bar openDCM]$ grep -iR -A 3 undependend
opendcm/core/reduction.hpp:     * @brief Create a undependend geometry equation 
opendcm/core/reduction.hpp-     * 
opendcm/core/reduction.hpp:     * This function creates the undependend geometry equation for a given vertex. This vertex must 
opendcm/core/reduction.hpp-     * be the source or target of the edge where the EquationHandler is added to. The result does 
opendcm/core/reduction.hpp-     * ignore all reduction results done on the edge.
opendcm/core/reduction.hpp-     * 
--
opendcm/core/reduction.hpp:     * @brief Create a undependend geometry equation in a \ref FlowGraph
opendcm/core/reduction.hpp-     * 
opendcm/core/reduction.hpp:     * This function creates the undependend geometry equation for a given vertex directly in a 
opendcm/core/reduction.hpp-     * \ref FlowGraph The given vertex must be the source or target of the edge where the 
opendcm/core/reduction.hpp-     * EquationHandler is added to. The result does ignore all reduction results done on the edge. 
opendcm/core/reduction.hpp-     * The returned node is unconnected. To allow initialisation of the equation it creates it is 
--
opendcm/core/reduction.hpp: * some times dependent, sometime undependend, it can be used to create the numeric equations for the 
opendcm/core/reduction.hpp- * symbolic reduction result.The provided interface is created to allow for late equation creation. The 
opendcm/core/reduction.hpp- * numeric Geometry must not be created at traversal time, but as the node reached in traversal is stored 
opendcm/core/reduction.hpp- * in the TreeWalker one can always access it later and use the functons provided here to create the 
--
opendcm/core/reduction.hpp: * @brief Node for Undependend Geometry
opendcm/core/reduction.hpp- * 
opendcm/core/reduction.hpp: * This node is used as starting point in the resuction tree, it provides a plain undependend Geometry.
opendcm/core/reduction.hpp- * As we know the numeric geometry type we have to use we can live only with the primitive Geometry,
opendcm/core/reduction.hpp- * no need to know any derived class.
opendcm/core/reduction.hpp- * 
[beast@beast openDCM]$ grep -iR -A 3 undependend
opendcm/core/reduction.hpp:     * @brief Create a undependend geometry equation 
opendcm/core/reduction.hpp-     * 
opendcm/core/reduction.hpp:     * This function creates the undependend geometry equation for a given vertex. This vertex must 
opendcm/core/reduction.hpp-     * be the source or target of the edge where the EquationHandler is added to. The result does 
opendcm/core/reduction.hpp-     * ignore all reduction results done on the edge.
opendcm/core/reduction.hpp-     * 
--
opendcm/core/reduction.hpp:     * @brief Create a undependend geometry equation in a \ref FlowGraph
opendcm/core/reduction.hpp-     * 
opendcm/core/reduction.hpp:     * This function creates the undependend geometry equation for a given vertex directly in a 
opendcm/core/reduction.hpp-     * \ref FlowGraph The given vertex must be the source or target of the edge where the 
opendcm/core/reduction.hpp-     * EquationHandler is added to. The result does ignore all reduction results done on the edge. 
opendcm/core/reduction.hpp-     * The returned node is unconnected. To allow initialisation of the equation it creates it is 
--
opendcm/core/reduction.hpp: * some times dependent, sometime undependend, it can be used to create the numeric equations for the 
opendcm/core/reduction.hpp- * symbolic reduction result.The provided interface is created to allow for late equation creation. The 
opendcm/core/reduction.hpp- * numeric Geometry must not be created at traversal time, but as the node reached in traversal is stored 
opendcm/core/reduction.hpp- * in the TreeWalker one can always access it later and use the functons provided here to create the 
--
opendcm/core/reduction.hpp: * @brief Node for Undependend Geometry
opendcm/core/reduction.hpp- * 
opendcm/core/reduction.hpp: * This node is used as starting point in the resuction tree, it provides a plain undependend Geometry.
opendcm/core/reduction.hpp- * As we know the numeric geometry type we have to use we can live only with the primitive Geometry,
opendcm/core/reduction.hpp- * no need to know any derived class.
opendcm/core/reduction.hpp- * 
```