### PR TITLE
Add therefor->therefore, therefor,

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -4937,6 +4937,7 @@ themslves->themselves
 ther->there, their, the, other,
 therafter->thereafter
 therby->thereby
+therefor->therefore, therefor,
 therfore->therefore
 theri->their
 theshold->threshold


### PR DESCRIPTION
seems that `therefor` is a legit legal word. But I added this entry because most likely it's `therefore`