### PR TITLE
README.rst: Remove obsolete comment about .py extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,6 @@ You can use ``pip`` to install codespell with e.g.::
 
     pip install codespell
 
-**Note:** that upon installation with "make install" we don't have the "py" suffix.
-
 Usage
 -----
 


### PR DESCRIPTION
The program is always called codespell, rather than codespell.py since commit
fb6f01d ("Move bin/codespell.py to bin/codespell"), and the "install" target
was removed in commit c5fe7f4 ("Remove borken parts of Makefile and repair
manpage creation").