### PR TITLE
Add the packaging metadata to build the codespell snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: codespell
+version: git
+summary: Check code for common misspellings
+description: |
+  Codespell fixes common mispellings in text files.It's designed
+  primarily for checking misspelled words in source code, but it can
+  be used with other files as well.
+grade: stable
+confinement: strict
+
+apps:
+  codespell:
+    command: codespell
+    plugs: [home, removable-media]
+
+parts:
+  codespell:
+    source: .
+    plugin: python


### PR DESCRIPTION
This package will let you publish the latest codespell in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.

It was packaged and released to the store by @royabouhamad during [google code-in](https://codein.withgoogle.com/). So, when you try to register the name you will find that it is already taken. You just have to fill the form claiming that you are the upstream developer, and we will take care of the transfer.