### PR TITLE
Add that that->that that, that, that the, that they, that this,

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -8255,7 +8255,7 @@ tghe->the
 thansk->thanks
 thant->than
 thast->that, that's,
-that that->that
+that that->that that, that, that the, that they, that this,
 that;s->that's
 thats'->that's
 thats->that's


### PR DESCRIPTION
`that that` is valid but many times I encounter it as a typo hence this PR.