### PR TITLE
Be more defensive

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3262,7 +3262,7 @@ entitys->entities
 entrepeneur->entrepreneur
 entrepeneurs->entrepreneurs
 entrys->entries
-enty->entry
+enty->entry, entity
 enumarate->enumerate
 enumarated->enumerated
 enumarates->enumerates
@@ -3628,7 +3628,7 @@ facist->fascist
 factorizaiton->factorization
 faild->failed
 faile->failed
-failt->fail
+failt->fail, failed,
 failue->failure
 failuer->failure
 failues->failures
@@ -9220,7 +9220,7 @@ whants->wants
 whataver->whatever
 whcih->which
 whe->when
-wheather->whether
+wheather->weather, whether,
 wheigh->weigh
 whenver->whenever
 wheras->whereas

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -3262,7 +3262,7 @@ entitys->entities
 entrepeneur->entrepreneur
 entrepeneurs->entrepreneurs
 entrys->entries
-enty->entry, entity
+enty->entry, entity,
 enumarate->enumerate
 enumarated->enumerated
 enumarates->enumerates


### PR DESCRIPTION
Be more defensive. The wrong words are not unique enough to make an automatic replacement without knowledge of the context. We do not know what the author of the original text was thinking.