### PR TITLE
.travis.yml: Check that the dictionary is sorted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
 
 script:
     - codespell --help
+    - make check-dictionary
     # this file has an error
     - "! codespell codespell_lib/tests/test_basic.py"
     - flake8

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ codespell.1: codespell.1.include bin/codespell
 	sed -i '/\.SS \"Usage/,+2d' codespell.1
 
 check-dictionary:
-	@if ! LANG=C sort ${SORT_ARGS} -c codespell_lib/data/dictionary.txt; then \
+	@if ! LC_ALL=C sort ${SORT_ARGS} -c codespell_lib/data/dictionary.txt; then \
 		echo "Dictionary not sorted. Sort with 'make sort-dictionary'"; \
 		exit 1; \
 	fi
 
 sort-dictionary:
-	LANG=C sort ${SORT_ARGS} -u -o codespell_lib/data/dictionary.txt codespell_lib/data/dictionary.txt
+	LC_ALL=C sort ${SORT_ARGS} -u -o codespell_lib/data/dictionary.txt codespell_lib/data/dictionary.txt
 
 pypi:
 	python setup.py sdist register upload

--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -7276,8 +7276,8 @@ reposoitory->repository
 repostiories->repositories
 repostiory->repository
 repport->report
-represenation->representation
 represantative->representative
+represenation->representation
 representaion->representation
 representaions->representations
 representiative->representative


### PR DESCRIPTION
To avoid committing an unsorted dictionary and having to fix it up later, check
that the dictionary is sorted in Travis-CI.

Closes #310.