### PR TITLE
manoeuvering, manoeuvre and manoeuvres are valid

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -5359,9 +5359,6 @@ mannor->manner
 mannual->manual
 mannually->manually
 manoeuverability->maneuverability
-manoeuvering->maneuvering
-manoeuvre->maneuver
-manoeuvres->maneuvers
 manouver->maneuver, manoeuvre,
 manouverability->maneuverability, manoeuvrability, manoeuverability,
 manouverable->maneuverable, manoeuvrable,


### PR DESCRIPTION
These are valid spellings in British English.