### PR TITLE
Revert "Create a Mozilla exclude list (#414)"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ include codespell_lib/__init__.py
 recursive-include codespell_lib *.py
 include codespell_lib/data/dictionary.txt
 include codespell_lib/data/linux-kernel.exclude
-include codespell_lib/data/mozilla.exclude

--- a/codespell_lib/data/mozilla.exclude
+++ b/codespell_lib/data/mozilla.exclude
@@ -1,4 +1,0 @@
-CAs
-optin
-aParent
-TE

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ if __name__ == "__main__":
           package_data={'codespell_lib': [
               op.join('data', 'dictionary.txt'),
               op.join('data', 'linux-kernel.exclude'),
-              op.join('data', 'mozilla.exclude'),
           ]},
           entry_points={
               'console_scripts': [


### PR DESCRIPTION
Should be into the Firefox tree instead

This reverts commit 17ad1f2b1d7303ca18b1940e5da418dbb971501f.